### PR TITLE
CI fix

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -9,6 +9,7 @@ let package = Package(
         .iOS(.v13),
         .tvOS(.v13),
         .watchOS(.v6),
+        .visionOS(.v1)
     ],
     products: [
         .library(


### PR DESCRIPTION
Fixed #6 by creating separate package description for Swift 5.9, because Github Actions only support Swift 5.7 for now.