### PR TITLE
Events order fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,9 @@ let package = Package(
             name: "EventSource",
             targets: ["EventSource"]),
     ],
-    dependencies: [
-         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0")
-    ],
     targets: [
         .target(
-            name: "EventSource",
-            dependencies: [
-                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms")
-            ]),
+            name: "EventSource"),
         .testTarget(
             name: "EventSourceTests",
             dependencies: ["EventSource"]),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,15 +16,9 @@ let package = Package(
             name: "EventSource",
             targets: ["EventSource"]),
     ],
-    dependencies: [
-         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0")
-    ],
     targets: [
         .target(
-            name: "EventSource",
-            dependencies: [
-                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms")
-            ]),
+            name: "EventSource"),
         .testTarget(
             name: "EventSourceTests",
             dependencies: ["EventSource"]),

--- a/README.md
+++ b/README.md
@@ -52,16 +52,14 @@ And then, include "EventSource" as a dependency for your target:
 
 ## Usage
 
-Using EventSource is easy. Simply create an instance of EventSource with the URLRequest of the SSE endpoint you want to connect to, and await for events:
+Using EventSource is easy. Simply create an new task from an instance of EventSource with the URLRequest of the SSE endpoint you want to connect to, and await for events:
 ```swift
 import EventSource
 
-...
+let eventSource = EventSource()
+let dataTask = eventSource.dataTask(for: urlRequest)
 
-let eventSource = EventSource(request: urlRequest)
-eventSource.connect()
-
-for await event in eventSource.events {
+for await event in dataTask.events() {
     switch event {
     case .open:
         print("Connection was opened.")
@@ -75,7 +73,7 @@ for await event in eventSource.events {
 }
 ```
 
-Use `close()` to explicilty close the connection.
+Use `dataTask.cancel()` to explicitly close the connection. However, in that case `.closed` event won't be emitted.
 
 ## Compatibility
 
@@ -87,7 +85,7 @@ Use `close()` to explicilty close the connection.
 
 ## Dependencies
 
-* Swift Async Algorithms https://github.com/apple/swift-async-algorithms
+No dependencies.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ And then, include "EventSource" as a dependency for your target:
 
 ## Usage
 
-Using EventSource is easy. Simply create an new task from an instance of EventSource with the URLRequest of the SSE endpoint you want to connect to, and await for events:
+Using EventSource is easy. Simply create a new task from an instance of EventSource with the URLRequest of the SSE endpoint you want to connect to, and await for events:
 ```swift
 import EventSource
 

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -6,7 +6,6 @@
 //  Licensed under the MIT License.
 //
 
-import AsyncAlgorithms
 import Foundation
 #if canImport(FoundationNetworking)
     import FoundationNetworking
@@ -17,7 +16,7 @@ import Foundation
 /// which sends events in `text/event-stream` format.
 /// The connection remains open until closed by calling `close()`.
 ///
-public final class EventSource {
+public struct EventSource {
     /// State of the connection.
     public enum ReadyState: Int {
         case none = -1
@@ -26,211 +25,204 @@ public final class EventSource {
         case closed = 2
     }
     
-    /// Events channel subject type.
-    public enum ChannelSubject {
+    /// Event type.
+    public enum EventType {
         case error(Error)
         case message(ServerMessage)
         case open
         case closed
     }
     
-    public var timeoutInterval: TimeInterval
-            
-    /// A number representing the state of the connection.
-    public private(set) var readyState: ReadyState = .none
-    
-    /// A string representing the URL of the source.
-    public let request: URLRequest
-    
     private let messageParser: MessageParser
     
-    public var maxRetryCount: Int
-    
-    public var retryDelay: Double
-    
-    private var currentRetryCount: Int = 1
-    
-    public private(set) var lastMessageId: String = ""
-    
-    /// Server-sent events channel.
-    public let events: AsyncChannel<ChannelSubject> = .init()
-    
-    private var urlSessionConfiguration: URLSessionConfiguration {
-        let configuration = URLSessionConfiguration.default
-        configuration.httpAdditionalHeaders = [
-            HTTPHeaderField.accept: Accept.eventStream,
-            HTTPHeaderField.cacheControl: CacheControl.noStore,
-            HTTPHeaderField.lastEventID: lastMessageId
-        ]
-        configuration.timeoutIntervalForRequest = self.timeoutInterval
-        configuration.timeoutIntervalForResource = self.timeoutInterval
-        return configuration
-    }
-    
-    private var urlSession: URLSession?
-        
-    private var dataTask: URLSessionDataTask?
-    
-    private var sessionDelegate = SessionDelegate()
-    
-    private var sessionDelegateTask: Task<Void, Error>?
-    
-    private var httpResponseErrorStatusCode: Int?
+    public var timeoutInterval: TimeInterval
     
     public init(
-        request: URLRequest,
         messageParser: MessageParser = .live,
-        maxRetryCount: Int = 3,
-        retryDelay: Double = 1.0,
         timeoutInterval: TimeInterval = 300
     ) {
-        self.request = request
         self.messageParser = messageParser
-        self.maxRetryCount = maxRetryCount
-        self.retryDelay = retryDelay
         self.timeoutInterval = timeoutInterval
     }
     
-    public func connect() {
-        guard readyState == .none || readyState == .connecting else {
-            return
+    public func dataTask(for urlRequest: URLRequest) -> DataTask {
+        DataTask(
+            urlRequest: urlRequest,
+            messageParser: messageParser,
+            timeoutInterval: timeoutInterval
+        )
+    }
+}
+
+public extension EventSource {
+    class DataTask {
+        /// A number representing the state of the connection.
+        public private(set) var readyState: ReadyState = .none
+        
+        public private(set) var lastMessageId: String = ""
+        
+        /// A string representing the URL of the source.
+        public let urlRequest: URLRequest
+        
+        private let messageParser: MessageParser
+        
+        private let timeoutInterval: TimeInterval
+        
+        private var urlSession: URLSession?
+        
+        private var sessionDelegate = SessionDelegate()
+        
+        private var sessionDelegateTask: Task<Void, Error>?
+        
+        private var urlSessionDataTask: URLSessionDataTask?
+                        
+        private var httpResponseErrorStatusCode: Int?
+        
+        private var urlSessionConfiguration: URLSessionConfiguration {
+            let configuration = URLSessionConfiguration.default
+            configuration.httpAdditionalHeaders = [
+                HTTPHeaderField.accept: Accept.eventStream,
+                HTTPHeaderField.cacheControl: CacheControl.noStore,
+                HTTPHeaderField.lastEventID: lastMessageId
+            ]
+            configuration.timeoutIntervalForRequest = self.timeoutInterval
+            configuration.timeoutIntervalForResource = self.timeoutInterval
+            return configuration
+        }
+                
+        internal init(
+            urlRequest: URLRequest,
+            messageParser: MessageParser,
+            timeoutInterval: TimeInterval
+        ) {
+            self.urlRequest = urlRequest
+            self.messageParser = messageParser
+            self.timeoutInterval = timeoutInterval
         }
         
-        urlSession = URLSession(
-            configuration: urlSessionConfiguration,
-            delegate: sessionDelegate,
-            delegateQueue: nil
-        )
-        dataTask = urlSession?.dataTask(with: request)
-        
-        handleDelegateUpdates()
-        
-        dataTask?.resume()
-        readyState = .connecting
-    }
-    
-    private func handleDelegateUpdates() {
-        sessionDelegate.onEvent = { [weak self] event in
-            self?.sessionDelegateTask = Task { [weak self] in
-                try Task.checkCancellation()
-
-                switch event {
-                case let .didCompleteWithError(error):
-                    await self?.handleSessionError(error)
-                case let .didReceiveResponse(response, completionHandler):
-                    await self?.handleSessionResponse(response, completionHandler: completionHandler)
-                case let .didReceiveData(data):
-                    await self?.parseMessages(from: data)
+        public func events() -> AsyncStream<EventType> {
+            AsyncStream { continuation in
+                continuation.onTermination = { @Sendable _ in
+                    close()
+                }
+                
+                urlSession = URLSession(
+                    configuration: urlSessionConfiguration,
+                    delegate: sessionDelegate,
+                    delegateQueue: nil
+                )
+                
+                sessionDelegate.onEvent = { event in
+                    switch event {
+                    case let .didCompleteWithError(error):
+                        handleSessionError(error)
+                    case let .didReceiveResponse(response, completionHandler):
+                        handleSessionResponse(response, completionHandler: completionHandler)
+                    case let .didReceiveData(data):
+                        parseMessages(from: data)
+                    }
+                }
+                
+                urlSessionDataTask = urlSession!.dataTask(with: urlRequest)
+                urlSessionDataTask!.resume()
+                readyState = .connecting
+                
+                func handleSessionError(_ error: Error?) {
+                    guard readyState != .closed else {
+                        close()
+                        return
+                    }
+                    
+                    // Send error event
+                    if let error {
+                        sendErrorEvent(with: error)
+                    }
+                            
+                    // Close connection
+                    close()
+                }
+                
+                func handleSessionResponse(
+                    _ response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+                ) {
+                    guard readyState != .closed else {
+                        completionHandler(.cancel)
+                        return
+                    }
+                    
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        completionHandler(.cancel)
+                        return
+                    }
+                            
+                    // Stop connection when 204 response code, otherwise keep open
+                    guard httpResponse.statusCode != 204 else {
+                        completionHandler(.cancel)
+                        close()
+                        return
+                    }
+                    
+                    if 200...299 ~= httpResponse.statusCode {
+                        if readyState != .open {
+                            setOpen()
+                        }
+                    } else {
+                        httpResponseErrorStatusCode = httpResponse.statusCode
+                    }
+                    
+                    completionHandler(.allow)
+                }
+                
+                /// Closes the connection, if one was made,
+                /// and sets the `readyState` property to `.closed`.
+                /// - Returns: State before closing.
+                @Sendable func close() {
+                    let previousState = self.readyState
+                    cancel()
+                    if previousState == .open {
+                        continuation.yield(.closed)
+                    }
+                }
+                
+                func parseMessages(from data: Data) {
+                    if let httpResponseErrorStatusCode {
+                        self.httpResponseErrorStatusCode = nil
+                        handleSessionError(
+                            EventSourceError.connectionError(statusCode: httpResponseErrorStatusCode, response: data)
+                        )
+                        return
+                    }
+                    
+                    let messages = messageParser.parse(data)
+                    
+                    // Update last message ID
+                    if let lastMessageWithId = messages.last(where: { $0.id != nil }) {
+                        lastMessageId = lastMessageWithId.id ?? ""
+                    }
+                    
+                    messages.forEach {
+                        continuation.yield(.message($0))
+                    }
+                }
+                
+                func setOpen() {
+                    readyState = .open
+                    continuation.yield(.open)
+                }
+                
+                func sendErrorEvent(with error: Error) {
+                    continuation.yield(.error(error))
                 }
             }
         }
-    }
-    
-    private func handleSessionError(_ error: Error?) async {
-        guard readyState != .closed else {
-            await close()
-            return
-        }
         
-        // Send error event
-        if let error {
-            await sendErrorEvent(with: error)
+        public func cancel() {
+            readyState = .closed
+            lastMessageId = ""
+            sessionDelegateTask?.cancel()
+            urlSessionDataTask?.cancel()
+            urlSession?.invalidateAndCancel()
         }
-                
-        // Retry connection or close
-        if currentRetryCount < maxRetryCount {
-            currentRetryCount += 1
-            try? await Task.sleep(duration: retryDelay)
-            connect()
-        } else {
-            await close()
-        }
-    }
-    
-    private func handleSessionResponse(
-        _ response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
-    ) async {
-        guard readyState != .closed else {
-            completionHandler(.cancel)
-            return
-        }
-        
-        guard let httpResponse = response as? HTTPURLResponse else {
-            completionHandler(.cancel)
-            return
-        }
-                
-        // Stop connection when 204 response code, otherwise keep open
-        guard httpResponse.statusCode != 204 else {
-            completionHandler(.cancel)
-            await close()
-            return
-        }
-        
-        if 200...299 ~= httpResponse.statusCode {
-            // Reset current retries count to allow retry on the next error
-            currentRetryCount = 1
-            
-            if readyState != .open {
-                await setOpen()
-            }
-        } else {
-            httpResponseErrorStatusCode = httpResponse.statusCode
-        }
-        
-        completionHandler(.allow)
-    }
-    
-    /// Closes the connection, if one was made,
-    /// and sets the `readyState` property to `.closed`.
-    public func close() async {
-        let previousState = readyState
-        readyState = .closed
-        lastMessageId = ""
-        sessionDelegateTask?.cancel()
-        dataTask?.cancel()
-        dataTask = nil
-        urlSession?.invalidateAndCancel()
-        urlSession = nil
-        
-        if previousState == .open {
-            await events.send(.closed)
-        }
-        
-        events.finish()
-    }
-    
-    private func parseMessages(from data: Data) async {
-        if let httpResponseErrorStatusCode {
-            self.httpResponseErrorStatusCode = nil
-            await handleSessionError(
-                EventSourceError.connectionError(statusCode: httpResponseErrorStatusCode, response: data)
-            )
-            return
-        }
-        
-        let messages = messageParser.parse(data)
-        
-        // Update last message ID
-        if let lastMessageWithId = messages.last(where: { $0.id != nil }) {
-            lastMessageId = lastMessageWithId.id ?? ""
-        }
-        
-        await messages.asyncForEach {
-            await events.send(.message($0))
-        }
-    }
-    
-    // MARK: - Fileprivate
-    
-    fileprivate func setOpen() async {
-        readyState = .open
-        
-        await events.send(.open)
-    }
-    
-    fileprivate func sendErrorEvent(with error: Error) async {
-        await events.send(.error(error))
     }
 }


### PR DESCRIPTION
Fixed events order bug reported in #3.
- Created new type `EventSource.DataTask` to handle requests.
- Replaced `AsyncChannel` with Swift's built-in `AsyncStream`.
- Removed `swift-async-algorithms` dependency, since it's no longer used.