### PR TITLE
Revert "Updated swift-tools-version"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.7
 
 import PackageDescription
 
@@ -9,7 +9,6 @@ let package = Package(
         .iOS(.v13),
         .tvOS(.v13),
         .watchOS(.v6),
-        .visionOS(.v1)
     ],
     products: [
         .library(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -9,6 +9,7 @@ let package = Package(
         .iOS(.v13),
         .tvOS(.v13),
         .watchOS(.v6),
+        .visionOS(.v1)
     ],
     products: [
         .library(


### PR DESCRIPTION
This reverts commit faa5fafd0d2322b4879670d84265491877c6b876 to fix builds on Swift 5.8 and 5.9.