### PR TITLE
fix: forget to call continuation.finish() causing task suspension

### DIFF
--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -214,7 +214,6 @@ public extension EventSource {
                 
                 func sendErrorEvent(with error: Error) {
                     continuation.yield(.error(error))
-                    continuation.finish()
                 }
             }
         }

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -182,6 +182,7 @@ public extension EventSource {
                     cancel()
                     if previousState == .open {
                         continuation.yield(.closed)
+                        continuation.finish()
                     }
                 }
                 
@@ -213,6 +214,7 @@ public extension EventSource {
                 
                 func sendErrorEvent(with error: Error) {
                     continuation.yield(.error(error))
+                    continuation.finish()
                 }
             }
         }


### PR DESCRIPTION
```swift
import EventSource

let eventSource = EventSource()
let dataTask = eventSource.dataTask(for: urlRequest)

for await event in dataTask.events() {
}

// Code blow will never be fired.
// And it will lead to memory leaks.
print("finish") // will not fire
```