### PR TITLE
Added ReadyState conformance to Sendable

### DIFF
--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -28,7 +28,7 @@ public struct EventSource: Sendable {
     }
 
     /// State of the connection.
-    public enum ReadyState: Int {
+    public enum ReadyState: Int, Sendable {
         case none = -1
         case connecting = 0
         case open = 1


### PR DESCRIPTION
Accessing ReadyState from outside the EventSourceActor results in a warning in Swift 5 and becomes an error in Swift 6.

This PR updates the ReadyState enum to conform to the Sendable protocol, allowing it to cross actor boundaries safely.