### PR TITLE
Caching data response for complete event parsing

### DIFF
--- a/Sources/EventSource/EventParser.swift
+++ b/Sources/EventSource/EventParser.swift
@@ -44,7 +44,7 @@ actor ServerEventParser: EventParser {
         // If event separator is not present do not parse any unfinished messages
         guard let lastSeparator = data.lastRange(of: separator) else { return ([], data) }
 
-        let bufferRange = data.startIndex..<lastSeparator.upperBound
+        let bufferRange = data.startIndex..<lastSeparator.lowerBound
         let remainingRange = lastSeparator.upperBound..<data.endIndex
 
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *) {

--- a/Sources/EventSource/EventParser.swift
+++ b/Sources/EventSource/EventParser.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public protocol EventParser: Sendable {
-    func parse(_ data: Data) async -> [EVEvent]
+    mutating func parse(_ data: Data) -> [EVEvent]
 }
 
 /// ``ServerEventParser`` is used to parse text data into ``ServerEvent``.
-actor ServerEventParser: EventParser {
+struct ServerEventParser: EventParser {
     private let mode: EventSource.Mode
     private var buffer = Data()
 
@@ -24,7 +24,7 @@ actor ServerEventParser: EventParser {
     static let lf: UInt8 = 0x0A
     static let colon: UInt8 = 0x3A
 
-    func parse(_ data: Data) -> [EVEvent] {
+    mutating func parse(_ data: Data) -> [EVEvent] {
         let (separatedMessages, remainingData) = splitBuffer(for: buffer + data)
         buffer = remainingData
         return parseBuffer(for: separatedMessages)
@@ -44,7 +44,7 @@ actor ServerEventParser: EventParser {
         // If event separator is not present do not parse any unfinished messages
         guard let lastSeparator = data.lastRange(of: separator) else { return ([], data) }
 
-        let bufferRange = data.startIndex..<lastSeparator.lowerBound
+        let bufferRange = data.startIndex..<lastSeparator.upperBound
         let remainingRange = lastSeparator.upperBound..<data.endIndex
 
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *) {

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -136,7 +136,7 @@ public extension EventSource {
 
             return AsyncStream { continuation in
                 let sessionDelegate = SessionDelegate()
-                let sesstionDelegateTask = Task { [weak self] in
+                let sessionDelegateTask = Task { [weak self] in
                     for await event in sessionDelegate.eventStream {
                         guard let self else { return }
 
@@ -153,12 +153,12 @@ public extension EventSource {
 
                 #if compiler(>=6.0)
                 continuation.onTermination = { @Sendable [weak self] _ in
-                    sesstionDelegateTask.cancel()
+                    sessionDelegateTask.cancel()
                     Task { await self?.close() }
                 }
                 #else
                 continuation.onTermination = { @Sendable _ in
-                    sesstionDelegateTask.cancel()
+                    sessionDelegateTask.cancel()
                     Task { [weak self] in
                         await self?.close()
                     }

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -91,7 +91,7 @@ public extension EventSource {
         /// A URLRequest of the events source.
         public let urlRequest: URLRequest
 
-        private let eventParser: EventParser
+        private var eventParser: EventParser
 
         private let timeoutInterval: TimeInterval
 
@@ -146,7 +146,7 @@ public extension EventSource {
                         case let .didReceiveResponse(response, completionHandler):
                             handleSessionResponse(response, completionHandler: completionHandler)
                         case let .didReceiveData(data):
-                            await parseMessages(from: data)
+                            parseMessages(from: data)
                         }
                     }
                 }
@@ -239,7 +239,7 @@ public extension EventSource {
             cancel()
         }
 
-        private func parseMessages(from data: Data) async {
+        private func parseMessages(from data: Data) {
             if let httpResponseErrorStatusCode {
                 self.httpResponseErrorStatusCode = nil
                 handleSessionError(
@@ -248,7 +248,7 @@ public extension EventSource {
                 return
             }
             
-            let events = await eventParser.parse(data)
+            let events = eventParser.parse(data)
 
             // Update last message ID
             if let lastMessageWithId = events.last(where: { $0.id != nil }) {

--- a/Sources/EventSource/EventSource.swift
+++ b/Sources/EventSource/EventSource.swift
@@ -146,7 +146,7 @@ public extension EventSource {
                         case let .didReceiveResponse(response, completionHandler):
                             handleSessionResponse(response, completionHandler: completionHandler)
                         case let .didReceiveData(data):
-                            parseMessages(from: data)
+                            await parseMessages(from: data)
                         }
                     }
                 }
@@ -239,7 +239,7 @@ public extension EventSource {
             cancel()
         }
 
-        private func parseMessages(from data: Data) {
+        private func parseMessages(from data: Data) async {
             if let httpResponseErrorStatusCode {
                 self.httpResponseErrorStatusCode = nil
                 handleSessionError(
@@ -248,7 +248,7 @@ public extension EventSource {
                 return
             }
             
-            let events = eventParser.parse(data)
+            let events = await eventParser.parse(data)
 
             // Update last message ID
             if let lastMessageWithId = events.last(where: { $0.id != nil }) {

--- a/Tests/EventSourceTests/EventParserTests.swift
+++ b/Tests/EventSourceTests/EventParserTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 struct EventParserTests {
     @Test func messagesParsing() async throws {
-        let parser = ServerEventParser()
+        var parser = ServerEventParser()
         
         let text = """
         data: test 1
@@ -31,7 +31,7 @@ struct EventParserTests {
         """
         let data = Data(text.utf8)
         
-        let messages = await parser.parse(data)
+        let messages = parser.parse(data)
 
         #expect(messages.count == 5)
         
@@ -60,7 +60,7 @@ struct EventParserTests {
     }
 
     @Test func emptyData() async {
-        let parser = ServerEventParser()
+        var parser = ServerEventParser()
 
         let text = """
         
@@ -68,13 +68,13 @@ struct EventParserTests {
         """
         let data = Data(text.utf8)
         
-        let messages = await parser.parse(data)
+        let messages = parser.parse(data)
 
         #expect(messages.isEmpty)
     }
     
     @Test func otherMessageFormats() async {
-        let parser = ServerEventParser()
+        var parser = ServerEventParser()
 
         let text = """
         data : test 1
@@ -98,7 +98,7 @@ struct EventParserTests {
         """
         let data = Data(text.utf8)
                 
-        let messages = await parser.parse(data)
+        let messages = parser.parse(data)
         
         #expect(messages[0].data != nil)
         #expect(messages[0].data! == "test 1")
@@ -129,7 +129,7 @@ struct EventParserTests {
     }
 
     @Test func dataOnlyMode() async throws {
-        let parser = ServerEventParser(mode: .dataOnly)
+        var parser = ServerEventParser(mode: .dataOnly)
         let jsonDecoder = JSONDecoder()
 
         let text = """
@@ -141,7 +141,7 @@ struct EventParserTests {
         """
         let data = Data(text.utf8)
 
-        let messages = await parser.parse(data)
+        let messages = parser.parse(data)
 
         let data1 = Data(try #require(messages[0].data?.utf8))
         let data2 = Data(try #require(messages[1].data?.utf8))
@@ -154,20 +154,20 @@ struct EventParserTests {
     }
 
     @Test func parseNotCompleteMessage() async throws {
-        let parser = ServerEventParser()
+        var parser = ServerEventParser()
 
         let text = """
         data: test 1
         """
         let data = Data(text.utf8)
 
-        let messages = await parser.parse(data)
+        let messages = parser.parse(data)
 
         #expect(messages.count == 0)
     }
 
     @Test func parseSeparatedMessage() async throws {
-        let parser = ServerEventParser()
+        var parser = ServerEventParser()
 
         let textPart1 = """
         event: add
@@ -181,8 +181,8 @@ struct EventParserTests {
         """
         let dataPart2 = Data(textPart2.utf8)
 
-        let _ = await parser.parse(dataPart1)
-        let messages = await parser.parse(dataPart2)
+        let _ = parser.parse(dataPart1)
+        let messages = parser.parse(dataPart2)
 
         #expect(messages.count == 1)
 

--- a/Tests/EventSourceTests/EventParserTests.swift
+++ b/Tests/EventSourceTests/EventParserTests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import EventSource
 
 struct EventParserTests {
-    @Test func messagesParsing() throws {
+    @Test func messagesParsing() async throws {
         let parser = ServerEventParser()
         
         let text = """
@@ -26,10 +26,12 @@ struct EventParserTests {
         id: 5
         event: ping
         data: test 5
+        
+        
         """
         let data = Data(text.utf8)
         
-        let messages = parser.parse(data)
+        let messages = await parser.parse(data)
 
         #expect(messages.count == 5)
         
@@ -56,8 +58,8 @@ struct EventParserTests {
         #expect(messages[4].event! == "ping")
         #expect(messages[4].data! == "test 5")
     }
-    
-    @Test func emptyData() {
+
+    @Test func emptyData() async {
         let parser = ServerEventParser()
 
         let text = """
@@ -66,12 +68,12 @@ struct EventParserTests {
         """
         let data = Data(text.utf8)
         
-        let messages = parser.parse(data)
+        let messages = await parser.parse(data)
 
         #expect(messages.isEmpty)
     }
     
-    @Test func otherMessageFormats() {
+    @Test func otherMessageFormats() async {
         let parser = ServerEventParser()
 
         let text = """
@@ -91,10 +93,12 @@ struct EventParserTests {
         
         message 6
         message 6-1
+        
+        
         """
         let data = Data(text.utf8)
                 
-        let messages = parser.parse(data)
+        let messages = await parser.parse(data)
         
         #expect(messages[0].data != nil)
         #expect(messages[0].data! == "test 1")
@@ -124,7 +128,7 @@ struct EventParserTests {
         #expect(messages[5].other!["message 6-1"] == "")
     }
 
-    @Test func dataOnlyMode() throws {
+    @Test func dataOnlyMode() async throws {
         let parser = ServerEventParser(mode: .dataOnly)
         let jsonDecoder = JSONDecoder()
 
@@ -133,10 +137,11 @@ struct EventParserTests {
 
         data: {"id":"abcd-2","type":"message","content":"\\n\\n"}
         
+        
         """
         let data = Data(text.utf8)
 
-        let messages = parser.parse(data)
+        let messages = await parser.parse(data)
 
         let data1 = Data(try #require(messages[0].data?.utf8))
         let data2 = Data(try #require(messages[1].data?.utf8))

--- a/Tests/EventSourceTests/EventParserTests.swift
+++ b/Tests/EventSourceTests/EventParserTests.swift
@@ -152,6 +152,45 @@ struct EventParserTests {
         #expect(message1.content == "\ntest\n")
         #expect(message2.content == "\n\n")
     }
+
+    @Test func parseNotCompleteMessage() async throws {
+        let parser = ServerEventParser()
+
+        let text = """
+        data: test 1
+        """
+        let data = Data(text.utf8)
+
+        let messages = await parser.parse(data)
+
+        #expect(messages.count == 0)
+    }
+
+    @Test func parseSeparatedMessage() async throws {
+        let parser = ServerEventParser()
+
+        let textPart1 = """
+        event: add
+        
+        """
+        let dataPart1 = Data(textPart1.utf8)
+        let textPart2 = """
+        data: test 1
+        
+        
+        """
+        let dataPart2 = Data(textPart2.utf8)
+
+        let _ = await parser.parse(dataPart1)
+        let messages = await parser.parse(dataPart2)
+
+        #expect(messages.count == 1)
+
+        #expect(messages[0].event != nil)
+        #expect(messages[0].data != nil)
+        #expect(messages[0].event! == "add")
+        #expect(messages[0].data! == "test 1")
+    }
 }
 
 fileprivate extension EventParserTests {


### PR DESCRIPTION
## Buffer
 
Add buffer in parser to store parts of the messages that are not complete, as mentioned in https://github.com/Recouse/EventSource/issues/19

Now parser would store received data parse full messages and retain remaining of the message to parse with next chunk

If the connection closes and buffer is not empty events are not processed, this behaviour is according to the SSE [documentation](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation)  

> If the file ends in the middle of an event, before the final empty line, the incomplete event is not dispatched. 

### Thread safety

To provide thread-safe access to buffer, parser is isolated to an actor.

### Test Cases Adjustments:

* [`Tests/EventSourceTests/EventParserTests.swift`](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0L11-R11): Modified test cases to support asynchronous parsing by updating the `parse` method calls to use `await`. Added new test cases to handle incomplete and separated messages. [[1]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0L11-R11) [[2]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0R29-R34) [[3]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0L60-R62) [[4]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0L69-R76) [[5]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0R96-R101) [[6]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0L127-R131) [[7]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0R140-R144) [[8]](diffhunk://#diff-cbcef472a8b31ad635e713b2f60b867c6898ac2f0aa3f5c8d151fd79a96605e0R155-R193)

## Typo

Fixed a typo in the `sessionDelegateTask` variable name. [[1]](diffhunk://#diff-f72a833f269bab200b154c730f81d4b708c18a22567e592a14dab54a2185ea58L139-R139) [[2]](diffhunk://#diff-f72a833f269bab200b154c730f81d4b708c18a22567e592a14dab54a2185ea58L149-R161) [[3]](diffhunk://#diff-f72a833f269bab200b154c730f81d4b708c18a22567e592a14dab54a2185ea58L242-R242) [[4]](diffhunk://#diff-f72a833f269bab200b154c730f81d4b708c18a22567e592a14dab54a2185ea58L251-R251)