### PR TITLE
Removed extra space trimming from the field name and value parsing

### DIFF
--- a/Sources/EventSource/ServerEvent.swift
+++ b/Sources/EventSource/ServerEvent.swift
@@ -79,12 +79,12 @@ public struct ServerEvent: EVEvent {
         
         for row in rows {
             // Skip the line if it is empty or it starts with a colon character
-            if row.isEmpty, row.first == ServerEventParser.colon {
+            if row.isEmpty || row.first == ServerEventParser.colon {
                 continue
             }
             
             let keyValue = row.split(separator: ServerEventParser.colon, maxSplits: 1)
-            let key = keyValue[0].utf8String.trimmingCharacters(in: .whitespaces)
+            let key = keyValue[0].utf8String
 
             // If value starts with a SPACE character, remove it from value
             let valueString = keyValue[safe: 1]?.utf8String

--- a/Sources/EventSource/ServerEvent.swift
+++ b/Sources/EventSource/ServerEvent.swift
@@ -85,8 +85,15 @@ public struct ServerEvent: EVEvent {
             
             let keyValue = row.split(separator: ServerEventParser.colon, maxSplits: 1)
             let key = keyValue[0].utf8String.trimmingCharacters(in: .whitespaces)
-            let value = keyValue[safe: 1]?.utf8String.trimmingCharacters(in: .whitespaces)
-            
+
+            // If value starts with a SPACE character, remove it from value
+            let valueString = keyValue[safe: 1]?.utf8String
+            let value = if let valueString, valueString.hasPrefix(" ") {
+                String(valueString.dropFirst())
+            } else {
+                valueString
+            }
+
             switch key {
             case "id":
                 message.id = value

--- a/Tests/EventSourceTests/EventParserTests.swift
+++ b/Tests/EventSourceTests/EventParserTests.swift
@@ -94,39 +94,24 @@ struct EventParserTests {
         message 6
         message 6-1
         
+        :
         
         """
         let data = Data(text.utf8)
                 
         let events = parser.parse(data)
 
-        let event0Data = try #require(events[safe: 0]?.data)
-        #expect(event0Data == "test 1")
+        // Due to extra spaces in the field names, the first four events failed to be interpreted correctly;
+        // therefore, only two events should be parsed
+        #expect(events.count == 2)
 
-        let event1ID = try #require(events[safe: 1]?.id)
-        let event1Data = try #require(events[safe: 1]?.data)
-        #expect(event1ID == "2")
-        #expect(event1Data == "test 2")
+        let event1Other = try #require(events[safe: 0]?.other?["test 5"])
+        #expect(event1Other == "")
 
-        let event2 = try #require(events[safe: 2]?.event)
-        let event2Data = try #require(events[safe: 2]?.data)
-        #expect(event2 == "add")
-        #expect(event2Data == " test 3")
-
-        let event3ID = try #require(events[safe: 3]?.id)
-        let event3 = try #require(events[safe: 3]?.event)
-        let event3Data = try #require(events[safe: 3]?.data)
-        #expect(event3ID == "4")
-        #expect(event3 == "ping")
-        #expect(event3Data == "test 4")
-
-        let event4Other = try #require(events[safe: 4]?.other?["test 5"])
-        #expect(event4Other == "")
-
-        let event5Other1 = try #require(events[safe: 5]?.other?["message 6"])
-        let event5Other2 = try #require(events[safe: 5]?.other?["message 6-1"])
-        #expect(event5Other1 == "")
-        #expect(event5Other2 == "")
+        let event2Other1 = try #require(events[safe: 1]?.other?["message 6"])
+        let event2Other2 = try #require(events[safe: 1]?.other?["message 6-1"])
+        #expect(event2Other1 == "")
+        #expect(event2Other2 == "")
     }
 
     @Test func dataOnlyMode() async throws {

--- a/Tests/EventSourceTests/EventParserTests.swift
+++ b/Tests/EventSourceTests/EventParserTests.swift
@@ -111,7 +111,7 @@ struct EventParserTests {
         let event2 = try #require(events[safe: 2]?.event)
         let event2Data = try #require(events[safe: 2]?.data)
         #expect(event2 == "add")
-        #expect(event2Data == "test 3")
+        #expect(event2Data == " test 3")
 
         let event3ID = try #require(events[safe: 3]?.id)
         let event3 = try #require(events[safe: 3]?.event)


### PR DESCRIPTION
Removed `trimmingCharacters(in:)` from the field name and value parsing. This overall improves compliance with the SSE specifications and resolves issue #23