### PR TITLE
Add /r/r support

### DIFF
--- a/Sources/EventSource/EventParser.swift
+++ b/Sources/EventSource/EventParser.swift
@@ -39,7 +39,7 @@ struct ServerEventParser: EventParser {
     }
 
     private func splitBuffer(for data: Data) -> (completeData: [Data], remainingData: Data) {
-        let separators: [[UInt8]] = [[Self.lf, Self.lf], [Self.cr, Self.lf, Self.cr, Self.lf]]
+        let separators: [[UInt8]] = [[Self.cr, Self.cr], [Self.lf, Self.lf], [Self.cr, Self.lf, Self.cr, Self.lf]]
         
         // find last range of our separator, most likely to be fast enough
         let (chosenSeparator, lastSeparatorRange) = findLastSeparator(in: data, separators: separators)


### PR DESCRIPTION
As specified in the SSE standard, \r\r (CR CR) is also a valid separator.​​

end-of-line = ( cr lf / cr / lf )  ; CRLF, CR, or LF are valid  