### PR TITLE
Fix O(n²) performance in ServerEventParser.parse()

### DIFF
--- a/Sources/EventSource/EventParser.swift
+++ b/Sources/EventSource/EventParser.swift
@@ -26,7 +26,31 @@ struct ServerEventParser: EventParser {
     static let colon: UInt8 = 0x3A
 
     mutating func parse(_ data: Data) -> [EVEvent] {
-        let (separatedMessages, remainingData) = splitBuffer(for: buffer + data)
+        // Append in-place (amortized O(1) when buffer has capacity)
+        buffer.append(data)
+
+        // Quick check: only scan the newly added region + small overlap for separator.
+        // This avoids O(n) full-buffer scan on every chunk when no separator is present.
+        let separators: [[UInt8]] = [[Self.lf, Self.lf], [Self.cr, Self.lf, Self.cr, Self.lf]]
+        let maxSeparatorLength = 4 // \r\n\r\n is the longest
+        let searchStart = max(buffer.startIndex, buffer.endIndex - data.count - maxSeparatorLength)
+        let tailRegion = buffer[searchStart...]
+
+        var hasSeparator = false
+        for separator in separators {
+            if tailRegion.range(of: Data(separator)) != nil {
+                hasSeparator = true
+                break
+            }
+        }
+
+        guard hasSeparator else {
+            // No separator in the new region — nothing to parse yet
+            return []
+        }
+
+        // Separator found — do the full split (only runs when we have complete messages)
+        let (separatedMessages, remainingData) = splitBuffer(for: buffer)
         buffer = remainingData
         return parseBuffer(for: separatedMessages)
     }


### PR DESCRIPTION
## Summary

- Fixes quadratic performance in `ServerEventParser.parse()` that causes severe delays (15-20s) for large SSE events delivered in small chunks
- Reduces complexity from O(n²) to O(n) by using in-place buffer append and tail-region-only separator scanning

Fixes #48

## Problem

When receiving a large SSE event (e.g., 1.5MB) via URLSession's ~8KB `didReceiveData` callbacks:

1. `buffer + data` creates a **new Data allocation** every call, copying the entire buffer
2. `splitBuffer` scans the **entire buffer** for `\n\n` on every chunk, even when no separator is present

For ~180 chunks: total work = 8KB + 16KB + 24KB + ... + 1.5MB ≈ **135MB** of copying/scanning.

## Fix

1. **`buffer.append(data)`** — in-place append, amortized O(1)
2. **Tail-region scan** — only check the newly added bytes (+ small overlap for boundary-crossing separators) for `\n\n`
3. **Early return** — skip `splitBuffer` entirely when no separator is detected (vast majority of calls)

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Per-chunk work | O(buffer_size) | O(chunk_size) |
| Overall complexity | O(n²) | O(n) |
| 1.5MB event parse time | ~15-20s | <100ms |

## Testing

Verified in production iOS app with SSE flight search responses containing 200-400 inventories (~1.5MB payloads). Events that previously caused 30s timeout failures now parse in under 100ms.