### PR TITLE
fix: add explicit default auth challenge handling to SessionDelegate

### DIFF
--- a/Sources/EventSource/SessionDelegate.swift
+++ b/Sources/EventSource/SessionDelegate.swift
@@ -46,4 +46,12 @@ final class SessionDelegate: NSObject, URLSessionDataDelegate {
     ) {
         internalStream.continuation.yield(.didReceiveData(data))
     }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        completionHandler(.performDefaultHandling, nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `urlSession(_:didReceive challenge:completionHandler:)` to `SessionDelegate` with `.performDefaultHandling`
- Fixes SSE connections silently failing when going through MITM proxies (mitmproxy, Charles Proxy, etc.)

Closes #50

## Problem

When using EventSource through an MITM proxy with a trusted CA certificate installed at the OS level, SSE connections fail silently. The request never reaches the proxy and no error events are emitted.

`SessionDelegate` implements `URLSessionDataDelegate` but does not implement the authentication challenge delegate method. While `URLSession` should fall back to default system trust evaluation, in practice this can cause connections to be silently rejected when a custom delegate is present without explicit challenge handling.

## Fix

Add explicit `.performDefaultHandling` to `SessionDelegate`:

```swift
func urlSession(
    _ session: URLSession,
    didReceive challenge: URLAuthenticationChallenge,
    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
) {
    completionHandler(.performDefaultHandling, nil)
}
```

This explicitly delegates to the system's default trust evaluation, which correctly respects user-installed CA certificates. This has **no effect** on normal (non-proxy) connections — it simply makes the default behavior explicit rather than implicit.